### PR TITLE
Add index to "popularity DESC, id ASC" of chair and estate

### DIFF
--- a/isucon10-qualify/app/0_Index.sql
+++ b/isucon10-qualify/app/0_Index.sql
@@ -5,6 +5,7 @@ CREATE INDEX `depth_idx` ON `isuumo`.`chair`(`depth`) USING BTREE;
 CREATE INDEX `kind_idx` ON `isuumo`.`chair`(`kind`) USING BTREE;
 CREATE INDEX `color_idx` ON `isuumo`.`chair`(`color`) USING BTREE;
 CREATE INDEX `stock_idx` ON `isuumo`.`chair`(`stock`) USING BTREE;
+CREATE INDEX `chair_popularity_desc_id_idx` ON `isuumo`.`chair`(`popularity_desc`, `id`) USING BTREE;
 
 CREATE INDEX `door_height_idx` ON `isuumo`.`estate`(`door_height`) USING BTREE;
 CREATE INDEX `door_width_idx` ON `isuumo`.`estate`(`door_width`) USING BTREE;
@@ -13,3 +14,4 @@ CREATE INDEX `features_idx` ON `isuumo`.`estate`(`features`) USING BTREE;
 CREATE INDEX `popularity_idx` ON `isuumo`.`estate`(`popularity`) USING BTREE;
 CREATE INDEX `latitude_idx` ON `isuumo`.`estate`(`latitude`) USING BTREE;
 CREATE INDEX `longitude_idx` ON `isuumo`.`estate`(`longitude`) USING BTREE;
+CREATE INDEX `estate_popularity_desc_id_idx` ON `isuumo`.`estate`(`popularity_desc`, `id`) USING BTREE;

--- a/isucon10-qualify/app/0_Schema.sql
+++ b/isucon10-qualify/app/0_Schema.sql
@@ -1,0 +1,40 @@
+DROP DATABASE IF EXISTS isuumo;
+CREATE DATABASE isuumo;
+
+DROP TABLE IF EXISTS isuumo.estate;
+DROP TABLE IF EXISTS isuumo.chair;
+
+CREATE TABLE isuumo.estate
+(
+    id              INTEGER                  NOT NULL PRIMARY KEY,
+    name            VARCHAR(64)              NOT NULL,
+    description     VARCHAR(4096)            NOT NULL,
+    thumbnail       VARCHAR(128)             NOT NULL,
+    address         VARCHAR(128)             NOT NULL,
+    latitude        DOUBLE PRECISION         NOT NULL,
+    longitude       DOUBLE PRECISION         NOT NULL,
+    rent            INTEGER                  NOT NULL,
+    door_height     INTEGER                  NOT NULL,
+    door_width      INTEGER                  NOT NULL,
+    features        VARCHAR(64)              NOT NULL,
+    popularity      INTEGER                  NOT NULL,
+    popularity_desc INTEGER AS (-popularity) NOT NULL
+);
+
+CREATE TABLE isuumo.chair
+(
+    id              INTEGER                  NOT NULL PRIMARY  KEY,
+    name            VARCHAR(64)              NOT NULL,                   
+    description     VARCHAR(4096)            NOT NULL,                   
+    thumbnail       VARCHAR(128)             NOT NULL,                   
+    price           INTEGER                  NOT NULL,                   
+    height          INTEGER                  NOT NULL,                   
+    width           INTEGER                  NOT NULL,                   
+    depth           INTEGER                  NOT NULL,                   
+    color           VARCHAR(64)              NOT NULL,                   
+    features        VARCHAR(64)              NOT NULL,                   
+    kind            VARCHAR(64)              NOT NULL,                   
+    popularity      INTEGER                  NOT NULL,                   
+    popularity_desc INTEGER AS (-popularity) NOT NULL,
+    stock           INTEGER                  NOT NULL                    
+);

--- a/isucon10-qualify/app/main.go
+++ b/isucon10-qualify/app/main.go
@@ -50,7 +50,7 @@ func main() {
 func initialize(c *fiber.Ctx) error {
     sqlDir := filepath.Join("..", "mysql", "db")
     paths := []string{
-        filepath.Join(sqlDir, "0_Schema.sql"),
+        filepath.Join(".", "0_Schema.sql"),
         filepath.Join(".", "0_Index.sql"),
         filepath.Join(sqlDir, "1_DummyEstateData.sql"),
         filepath.Join(sqlDir, "2_DummyChairData.sql"),
@@ -272,7 +272,7 @@ func searchChairs(c *fiber.Ctx) error {
     searchQuery := "SELECT * FROM chair WHERE "
     countQuery := "SELECT COUNT(*) FROM chair WHERE "
     searchCondition := strings.Join(conditions, " AND ")
-    limitOffset := " ORDER BY popularity DESC, id ASC LIMIT ? OFFSET ?"
+    limitOffset := " ORDER BY popularity_desc, id LIMIT ? OFFSET ?"
 
     var res ChairSearchResponse
     err = db.Get(&res.Count, countQuery+searchCondition, params...)
@@ -542,7 +542,7 @@ func searchEstates(c *fiber.Ctx) error {
     searchQuery := "SELECT * FROM estate WHERE "
     countQuery := "SELECT COUNT(*) FROM estate WHERE "
     searchCondition := strings.Join(conditions, " AND ")
-    limitOffset := " ORDER BY popularity DESC, id ASC LIMIT ? OFFSET ?"
+    limitOffset := " ORDER BY popularity_desc, id LIMIT ? OFFSET ?"
 
     var res EstateSearchResponse
     err = db.Get(&res.Count, countQuery+searchCondition, params...)
@@ -608,7 +608,7 @@ func searchRecommendedEstateWithChair(c *fiber.Ctx) error {
     w := chair.Width
     h := chair.Height
     d := chair.Depth
-    query = `SELECT * FROM estate WHERE (door_width >= ? AND door_height >= ?) OR (door_width >= ? AND door_height >= ?) OR (door_width >= ? AND door_height >= ?) OR (door_width >= ? AND door_height >= ?) OR (door_width >= ? AND door_height >= ?) OR (door_width >= ? AND door_height >= ?) ORDER BY popularity DESC, id ASC LIMIT ?`
+    query = `SELECT * FROM estate WHERE (door_width >= ? AND door_height >= ?) OR (door_width >= ? AND door_height >= ?) OR (door_width >= ? AND door_height >= ?) OR (door_width >= ? AND door_height >= ?) OR (door_width >= ? AND door_height >= ?) OR (door_width >= ? AND door_height >= ?) ORDER BY popularity_desc, id LIMIT ?`
     err = db.Select(&estates, query, w, h, w, d, h, w, h, d, d, w, d, h, Limit)
     if err != nil {
         if err == sql.ErrNoRows {
@@ -643,7 +643,7 @@ func searchEstateNazotte(c *fiber.Ctx) error {
 
     b := coordinates.getBoundingBox()
     estatesInBoundingBox := []Estate{}
-    query := `SELECT * FROM estate WHERE latitude <= ? AND latitude >= ? AND longitude <= ? AND longitude >= ? ORDER BY popularity DESC, id ASC`
+    query := `SELECT * FROM estate WHERE latitude <= ? AND latitude >= ? AND longitude <= ? AND longitude >= ? ORDER BY popularity_desc, id`
     err = db.Select(&estatesInBoundingBox, query, b.BottomRightCorner.Latitude, b.TopLeftCorner.Latitude, b.BottomRightCorner.Longitude, b.TopLeftCorner.Longitude)
     if err == sql.ErrNoRows {
         logger.Infof("select * from estate where latitude ...", err)


### PR DESCRIPTION
https://dev.mysql.com/doc/refman/8.0/en/order-by-optimization.html
It seems that the index doesn't work if DESC and ASC are mixed in ORDER BY.

https://dev.mysql.com/doc/refman/5.7/en/create-table-generated-columns.html
So I created a generated column named "popularity_desc", changed some SQL so that the ORDER BY is only ASC, and added an index.It seems that the index doesn't work if DESC and ASC are mixed in ORDER BY.